### PR TITLE
Add login form on homepage

### DIFF
--- a/src/routes/(marketing)/+page.server.ts
+++ b/src/routes/(marketing)/+page.server.ts
@@ -1,0 +1,9 @@
+import type { PageServerLoad } from './$types'
+
+export const load: PageServerLoad = async ({ locals: { session }, cookies, url }) => {
+  return {
+    url: url.origin,
+    cookies: cookies.getAll(),
+    session
+  }
+}

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -5,6 +5,9 @@
     WebsiteDescription,
   } from "./../../config"
 
+  import { Auth } from "@supabase/auth-ui-svelte"
+  import { sharedAppearance, oauthProviders } from "./login/login_config"
+
   const ldJson = {
     "@context": "https://schema.org",
     "@type": "WebSite",
@@ -220,6 +223,7 @@
       `,
     },
   ]
+  let { data } = $props()
 </script>
 
 <svelte:head>
@@ -295,6 +299,21 @@
         </a>
       </div>
     </div>
+  </div>
+</div>
+<div class="max-w-lg mx-auto my-10">
+  <Auth
+    supabaseClient={data.supabase}
+    view="sign_in"
+    redirectTo={`${data.url}/auth/callback`}
+    providers={oauthProviders}
+    socialLayout="horizontal"
+    showLinks={false}
+    appearance={sharedAppearance}
+    additionalData={undefined}
+  />
+  <div class="text-l text-slate-800 mt-4 text-center">
+    <a class="underline" href="/login/forgot_password">Forgot password?</a>
   </div>
 </div>
 <div class="min-h-[60vh]">

--- a/src/routes/(marketing)/+page.ts
+++ b/src/routes/(marketing)/+page.ts
@@ -1,1 +1,31 @@
-export const prerender = true
+import {
+  PUBLIC_SUPABASE_ANON_KEY,
+  PUBLIC_SUPABASE_URL
+} from '$env/static/public'
+import {
+  createBrowserClient,
+  createServerClient,
+  isBrowser
+} from '@supabase/ssr'
+
+export const ssr = false
+
+export const load = async ({ fetch, data, depends }) => {
+  depends('supabase:auth')
+
+  const supabase = isBrowser()
+    ? createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+        global: { fetch }
+      })
+    : createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+        global: { fetch },
+        cookies: {
+          getAll() {
+            return data.cookies
+          }
+        }
+      })
+
+  const url = data.url
+  return { supabase, url }
+}


### PR DESCRIPTION
## Summary
- create server load for homepage
- generate Supabase client in home page load
- import Supabase Auth on the home page and embed sign-in form

## Testing
- `bash checks.sh` *(fails: Cannot find package 'prettier-plugin-svelte')*